### PR TITLE
Add -U option to send NMEA to extra UDP destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Use: rtl_ais [options] [outputfile]
         Built-in AIS decoder options:
         [-h host (default: 127.0.0.1)]
         [-P port (default: 10110)]
+        [-U host:port also send NMEA to this UDP address (repeatable)]
         [-T use TCP communication as tcp listener ( -h is ignored)]
         [-t time to keep ais messages in sec, using tcp listener (default: 15)]
         [-n log NMEA sentences to console (stderr) (default off)]

--- a/aisdecoder/aisdecoder.c
+++ b/aisdecoder/aisdecoder.c
@@ -53,6 +53,14 @@ static int sock;
 static int use_tcp = 0;
 
 static struct addrinfo* addr=NULL;
+
+// extra UDP fan-out destinations (-U), sent in addition to -h/-P
+#define MAX_UDP_EXTRA 16
+static char *extra_host[MAX_UDP_EXTRA];
+static char *extra_port[MAX_UDP_EXTRA];
+static struct addrinfo *extra_addr[MAX_UDP_EXTRA];
+static int n_extra = 0;
+
 // messages can be retrived from a different thread
 static pthread_mutex_t message_mutex;
 
@@ -108,6 +116,24 @@ const char *aisdecoder_next_message()
 
 static int initSocket(const char *host, const char *portname);
 int send_nmea( const char *sentence, unsigned int length);
+int isBroadcastAddress(const char *ipAddress);
+
+// address is resolved later, in init_ais_decoder()
+int aisdecoder_add_udp_destination(const char *hostport) {
+	const char *c = strrchr(hostport, ':');
+	size_t hlen;
+	if (n_extra >= MAX_UDP_EXTRA || !c || c == hostport || !c[1]) {
+		fprintf(stderr, "Bad or too many -U destination: '%s'\n", hostport);
+		return 0;
+	}
+	hlen = (size_t)(c - hostport);
+	extra_host[n_extra] = malloc(hlen + 1);
+	memcpy(extra_host[n_extra], hostport, hlen);
+	extra_host[n_extra][hlen] = '\0';
+	extra_port[n_extra] = strdup(c + 1);
+	n_extra++;
+	return 1;
+}
 
 void sound_level_changed(float level, int channel, unsigned char high) {
     if (high != 0)
@@ -152,6 +178,11 @@ int send_nmea( const char *sentence, unsigned int length) {
 		return add_nmea_ais_message(sentence, length);
 	}
 	else if(sock) {
+		int i;
+		// also send to each -U fan-out destination (best-effort, never fatal)
+		for (i = 0; i < n_extra; i++)
+			if (extra_addr[i])
+				sendto(sock, sentence, length, 0, extra_addr[i]->ai_addr, extra_addr[i]->ai_addrlen);
 		return sendto(sock, sentence, length, 0, addr->ai_addr, addr->ai_addrlen);
 	}
         return 0;
@@ -173,6 +204,24 @@ int init_ais_decoder(char * host, char * port ,int show_levels,int _debug_nmea,i
 	else {
 		if (!initTcpSocket(port, debug_nmea, tcp_keep_ais_time)) {
 			return EXIT_FAILURE;
+		}
+	}
+	// resolve -U destinations, reusing the socket from initSocket()
+	if (n_extra > 0 && sock) {
+		int i, enable = 1;
+		struct addrinfo hints;
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_family = AF_UNSPEC;
+		hints.ai_socktype = SOCK_DGRAM;
+		hints.ai_protocol = IPPROTO_UDP;
+		for (i = 0; i < n_extra; i++) {
+			if (getaddrinfo(extra_host[i], extra_port[i], &hints, &extra_addr[i]) != 0) {
+				fprintf(stderr, "Failed to resolve -U %s:%s\n", extra_host[i], extra_port[i]);
+				return EXIT_FAILURE;
+			}
+			if (isBroadcastAddress(extra_host[i]))
+				setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &enable, sizeof(enable));
+			fprintf(stderr, "AIS data will also be sent to %s:%s\n", extra_host[i], extra_port[i]);
 		}
 	}
     if (show_levels) on_sound_level_changed=sound_level_changed;
@@ -202,6 +251,14 @@ int free_ais_decoder(void)
     
     freeSoundDecoder();
     freeaddrinfo(addr);
+    {
+        int i;
+        for (i = 0; i < n_extra; i++) {
+            if (extra_addr[i]) freeaddrinfo(extra_addr[i]);
+            free(extra_host[i]);
+            free(extra_port[i]);
+        }
+    }
 #ifdef WIN32
     WSACleanup();
 #endif

--- a/aisdecoder/aisdecoder.h
+++ b/aisdecoder/aisdecoder.h
@@ -1,6 +1,7 @@
 #ifndef __AIS_RL_AIS_INC_
 #define  __AIS_RL_AIS_INC_
 int init_ais_decoder(char * host, char * port,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time, int add_sample_num);
+int aisdecoder_add_udp_destination(const char *hostport);
 void run_rtlais_decoder(short * buff, int len);
 const char *aisdecoder_next_message();
 int free_ais_decoder(void);

--- a/main.c
+++ b/main.c
@@ -25,6 +25,7 @@
 typedef void* rtlsdr_dev_t;
 #include "convenience.h"
 #include "rtl_ais.h"
+#include "aisdecoder/aisdecoder.h"
 
 void usage(void)
 {
@@ -53,6 +54,7 @@ void usage(void)
 		"\tBuilt-in AIS decoder options:\n"
 		"\t[-h host (default: 127.0.0.1)]\n"
 		"\t[-P port (default: 10110)]\n"
+		"\t[-U host:port also send NMEA to this UDP address (repeatable)]\n"
 		"\t[-T use TCP communication, rtl-ais is tcp server ( -h is ignored)\n"
 		"\t[-t time to keep ais messages in sec, using tcp listener (default: 15)\n"
 		"\t[-n log NMEA sentences to console (stderr) (default off)]\n"
@@ -105,7 +107,7 @@ int main(int argc, char **argv)
         config.host = strdup("127.0.0.1");
         config.port = strdup("10110");
         
-	while ((opt = getopt(argc, argv, "l:r:s:o:EODd:g:p:RATIt:P:h:nLS:?")) != -1)
+	while ((opt = getopt(argc, argv, "l:r:s:o:EODd:g:p:RATIt:P:h:nLS:U:?")) != -1)
 	{
 		switch (opt) {
 		case 'l':
@@ -160,6 +162,10 @@ int main(int argc, char **argv)
                         break;
 		case 'h':
 			config.host=strdup(optarg);
+			break;
+		case 'U':
+			if (!aisdecoder_add_udp_destination(optarg))
+				return 2;
 			break;
 		case 'L':
 			config.show_levels=1;


### PR DESCRIPTION
Adds a repeatable -U host:port option that sends each NMEA sentence to one or more additional UDP destinations, on top of the normal -h/-P output. This lets a single receiver feed several endpoints (local broadcasts, remote aggregators) without an external multiplexer.

Additive only: with no -U the behaviour is unchanged, and the extra sends reuse the existing UDP socket. SO_BROADCAST is enabled automatically when a -U address is a broadcast address.